### PR TITLE
Update Darwin Urls

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -3,6 +3,4 @@
 DaRWIN also stands for Data Research Warehouse Information Network.
 This tool is used to manage your natural sciences collections
 
-This is a Mirror of the repo hosted in our office at :
-
-[http://projects.naturalsciences.be/projects/darwin]
+[https://github.com/naturalsciences/Darwin/]

--- a/apps/backend/i18n/en/messages.xml
+++ b/apps/backend/i18n/en/messages.xml
@@ -4352,8 +4352,8 @@
         <target>This application requires an authentication.</target>
       </trans-unit>
       <trans-unit id="1353">
-        <source>Since Darwin is an Open Source application entirely based on open source software, we would be glad if you want to contribute to the project.&lt;br/&gt; Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : &lt;a href=&quot;http://projects.naturalsciences.be/projects/darwin&quot;&gt;http://projects.naturalsciences.be/projects/darwin&lt;/a&gt;</source>
-        <target>Since Darwin is an Open Source application entirely based on open source software, we would be glad if you want to contribute to the project.&lt;br/&gt; Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : &lt;a href=&quot;http://projects.naturalsciences.be/projects/darwin&quot;&gt;http://projects.naturalsciences.be/projects/darwin&lt;/a&gt;</target>
+        <source>Since Darwin is an Open Source application entirely based on open source software, we would be glad if you want to contribute to the project.&lt;br/&gt; Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : &lt;a href=&quot;https://github.com/naturalsciences/Darwin/&quot;&gt;https://github.com/naturalsciences/Darwin/&lt;/a&gt;</source>
+        <target>Since Darwin is an Open Source application entirely based on open source software, we would be glad if you want to contribute to the project.&lt;br/&gt; Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : &lt;a href=&quot;https://github.com/naturalsciences/Darwin/&quot;&gt;https://github.com/naturalsciences/Darwin/&lt;/a&gt;</target>
       </trans-unit>
       <trans-unit id="1354">
         <source>This specimen already exists</source>

--- a/apps/backend/i18n/es_ES/messages.xml
+++ b/apps/backend/i18n/es_ES/messages.xml
@@ -5207,7 +5207,7 @@
         
       </trans-unit>
       <trans-unit id="1353">
-        <source>Since Darwin is an Open Source application entirely based on open source software, we would be glad if you want to contribute to the project.&lt;br/&gt; Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : &lt;a href=&quot;http://projects.naturalsciences.be/projects/darwin&quot;&gt;http://projects.naturalsciences.be/projects/darwin&lt;/a&gt;</source>
+        <source>Since Darwin is an Open Source application entirely based on open source software, we would be glad if you want to contribute to the project.&lt;br/&gt; Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : &lt;a href=&quot;https://github.com/naturalsciences/Darwin/&quot;&gt;https://github.com/naturalsciences/Darwin/&lt;/a&gt;</source>
         
       </trans-unit>
       <trans-unit id="1354">

--- a/apps/backend/i18n/fr/messages.xml
+++ b/apps/backend/i18n/fr/messages.xml
@@ -5439,8 +5439,8 @@
         
       </trans-unit>
       <trans-unit id="1353">
-        <source>Since Darwin is an Open Source application entirely based on open source software, we would be glad if you want to contribute to the project.&lt;br/&gt; Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : &lt;a href=&quot;http://projects.naturalsciences.be/projects/darwin&quot;&gt;http://projects.naturalsciences.be/projects/darwin&lt;/a&gt;</source>
-        <target>Darwin est une application Open Source entièrement basée sur des logiciels open source. Nous serions dès lors heureux d’accueillir des nouveaux contributeurs. Suggestions &lt;br/&gt;, patches, rapports de bogues ou code sont les bienvenus sur notre gestionnaire de projet : &lt;a href=&quot;http://projects.naturalsciences.be/projects/darwin&quot;&gt;http://projects.naturalsciences.be/projects/darwin&lt;/a&gt;</target>
+        <source>Since Darwin is an Open Source application entirely based on open source software, we would be glad if you want to contribute to the project.&lt;br/&gt; Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : &lt;a href=&quot;https://github.com/naturalsciences/Darwin/&quot;&gt;https://github.com/naturalsciences/Darwin/&lt;/a&gt;</source>
+        <target>Darwin est une application Open Source entièrement basée sur des logiciels open source. Nous serions dès lors heureux d’accueillir des nouveaux contributeurs. Suggestions &lt;br/&gt;, patches, rapports de bogues ou code sont les bienvenus sur notre gestionnaire de projet : &lt;a href=&quot;https://github.com/naturalsciences/Darwin/&quot;&gt;https://github.com/naturalsciences/Darwin/&lt;/a&gt;</target>
         
       </trans-unit>
       <trans-unit id="1354">

--- a/apps/backend/i18n/nl/messages.xml
+++ b/apps/backend/i18n/nl/messages.xml
@@ -5434,8 +5434,8 @@
         
       </trans-unit>
       <trans-unit id="1353">
-        <source>Since Darwin is an Open Source application entirely based on open source software, we would be glad if you want to contribute to the project.&lt;br/&gt; Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : &lt;a href=&quot;http://projects.naturalsciences.be/projects/darwin&quot;&gt;http://projects.naturalsciences.be/projects/darwin&lt;/a&gt;</source>
-        <target>Aangezien DaRWIN volledig gebaseerd is op open source software, zouden we ons verheugen mocht u wensen bij te dragen tot ons project.&lt;br /&gt; Suggesties, Patches, het doorgeven van Foutmeldingen of code sponsering zijn welkom op onze trac : &lt;a href=&quot;http://projects.naturalsciences.be/projects/darwin&quot;&gt;http://projects.naturalsciences.be/projects/darwin&lt;/a&gt;;</target>
+        <source>Since Darwin is an Open Source application entirely based on open source software, we would be glad if you want to contribute to the project.&lt;br/&gt; Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : &lt;a href=&quot;https://github.com/naturalsciences/Darwin/&quot;&gt;https://github.com/naturalsciences/Darwin/&lt;/a&gt;</source>
+        <target>Aangezien DaRWIN volledig gebaseerd is op open source software, zouden we ons verheugen mocht u wensen bij te dragen tot ons project.&lt;br /&gt; Suggesties, Patches, het doorgeven van Foutmeldingen of code sponsering zijn welkom op onze trac : &lt;a href=&quot;https://github.com/naturalsciences/Darwin/&quot;&gt;https://github.com/naturalsciences/Darwin/&lt;/a&gt;;</target>
         
       </trans-unit>
       <trans-unit id="1354">

--- a/apps/backend/modules/help/templates/contribSuccess.php
+++ b/apps/backend/modules/help/templates/contribSuccess.php
@@ -3,6 +3,6 @@
   <h1><?php echo __('Contribute');?> :</h1>
   <p>
 	<?php echo __('Since Darwin is Open Source application, and entirely based on open source software, we would be glad if you want to contribute to the project.<br />
-	Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : <a href="http://projects.naturalsciences.be/projects/darwin">http://projects.naturalsciences.be/projects/darwin</a>');?>
+	Suggestions, Patches, Bug Reports or Code Donations are welcome on our Request tracker : <a href="https://github.com/naturalsciences/Darwin/">https://github.com/naturalsciences/Darwin/</a>');?>
   </p>
 </div>


### PR DESCRIPTION
Although I know  that the old repository is still used, 
the project manager platform is no longer used.
So Here is a proposal to remove all urls pointing to projects.naturalsciences.be.

